### PR TITLE
Stripped configuration out into separate classes

### DIFF
--- a/CommandConfiguration/GreetCommandConfiguration.cs
+++ b/CommandConfiguration/GreetCommandConfiguration.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using ConsoleStarter.Commands;
+using Microsoft.Extensions.CommandLineUtils;
+
+namespace ConsoleStarter.CommandConfiguration
+{
+    public static class GreetCommandConfiguration
+    {
+        public static void Configure(CommandLineApplication command, CommandLineOptions options)
+        {
+
+            command.Description = "An example command from the neat .NET Core Starter";
+            command.HelpOption("--help|-h|-?");
+
+            var nameArgument = command.Argument("name",
+                                   "Name I should say hello to");
+
+            command.OnExecute(() =>
+            {
+                options.Command = new GreetCommand(nameArgument.Value, options);
+
+                return 0;
+            });
+
+        }
+    }
+}

--- a/CommandConfiguration/RootCommandConfiguration.cs
+++ b/CommandConfiguration/RootCommandConfiguration.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using ConsoleStarter.Commands;
+using Microsoft.Extensions.CommandLineUtils;
+
+namespace ConsoleStarter.CommandConfiguration
+{
+    public static class RootCommandConfiguration
+    {
+        public static void Configure(CommandLineApplication app, CommandLineOptions options)
+        {
+
+            app.Command("greet", c => GreetCommandConfiguration.Configure(c, options));
+
+            app.OnExecute(() =>
+            {
+                options.Command = new RootCommand(app);
+
+                return 0;
+            });
+
+        }
+    }
+}

--- a/CommandLineOptions.cs
+++ b/CommandLineOptions.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.CommandLineUtils;
 using ConsoleStarter.Commands;
+using ConsoleStarter.CommandConfiguration;
 
 namespace ConsoleStarter
 {
@@ -27,7 +28,7 @@ namespace ConsoleStarter
 
 
 
-            RootCommand.Configure(app, options);
+            RootCommandConfiguration.Configure(app, options);
 
             var result = app.Execute(args);
 

--- a/Commands/GreetCommand.cs
+++ b/Commands/GreetCommand.cs
@@ -7,24 +7,6 @@ namespace ConsoleStarter.Commands
     public class GreetCommand : ICommand
     {
 
-        public static void Configure(CommandLineApplication command, CommandLineOptions options)
-        {
-
-            command.Description = "An example command from the neat .NET Core Starter";
-            command.HelpOption("--help|-h|-?");
-
-            var nameArgument = command.Argument("name",
-                                   "Name I should say hello to");
-
-            command.OnExecute(() =>
-                {
-                    options.Command = new GreetCommand(nameArgument.Value, options);
-
-                    return 0;
-                });
-
-        }
-
         private readonly string _name;
         private readonly CommandLineOptions _options;
 
@@ -34,11 +16,13 @@ namespace ConsoleStarter.Commands
             _options = options;
         }
 
-        public void Run()
+        public int Run()
         {
             Console.WriteLine("Hello "
                 + (_name != null ? _name : "World")
                 + (_options.IsEnthousiastic ? "!!!" : "."));
+
+            return 0;
         }
 
     }

--- a/Commands/ICommand.cs
+++ b/Commands/ICommand.cs
@@ -3,7 +3,7 @@ namespace ConsoleStarter
 
     public interface ICommand
     {
-        void Run();
+        int Run();
     }
 
 }

--- a/Commands/RootCommand.cs
+++ b/Commands/RootCommand.cs
@@ -5,21 +5,6 @@ namespace ConsoleStarter.Commands
 
     public class RootCommand : ICommand
     {
-
-        public static void Configure(CommandLineApplication app, CommandLineOptions options)
-        {
-
-            app.Command("greet", c => GreetCommand.Configure(c, options));
-
-            app.OnExecute(() =>
-                {
-                    options.Command = new RootCommand(app);
-
-                    return 0;
-                });
-
-        }
-
         private readonly CommandLineApplication _app;
 
         public RootCommand(CommandLineApplication app)
@@ -27,9 +12,11 @@ namespace ConsoleStarter.Commands
             _app = app;
         }
 
-        public void Run()
+        public int Run()
         {
             _app.ShowHelp();
+
+            return 1;
         }
 
     }

--- a/Program.cs
+++ b/Program.cs
@@ -17,9 +17,7 @@ namespace ConsoleStarter
                 return 1;
             }
 
-            options.Command.Run();
-
-            return 0;
+            return options.Command.Run();
 
         }
     }


### PR DESCRIPTION
In [Structuring Neat .NET Core Command Line Apps Neatly](https://gist.github.com/iamarcel/9bdc3f40d95c13f80d259b7eb2bbcabb) you wrote about _Separation of Concerns_, and this can be taken a step further. 

I extracted the _configuration_ in separate classes, therefore the _command_-classes do only their thing, without any config and so on.

Another step further the global-options could be extracted in a separate class. I didn't do this in this PR, but I made -- based on your introduction -- this in https://bitbucket.org/gfoidltests/commandlinetest


PS: Thanks for the very helpful introduction to this cool feature